### PR TITLE
add link to build infromation page(on gh-pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ GUI Git Client
 * Run on Windows, macOS and Linux
 * Written in C++
 * Powered by Qt 5
+
+## How to build
+
+Watch [Build information page](https://soramimi.github.io/Guitar/build.html)


### PR DESCRIPTION
#1 で``gh-pages``が有効になったので、ReadmeからLinkを貼ろうという提案