### PR TITLE
Linux でビルドできないのを改善

### DIFF
--- a/Guitar.pro
+++ b/Guitar.pro
@@ -51,6 +51,10 @@ macx {
 	QMAKE_BUNDLE_DATA += t
 }
 
+unix {
+    LIBS += -lz
+}
+
 SOURCES += \
 	version.c \
 	src/main.cpp\

--- a/src/GitPack.cpp
+++ b/src/GitPack.cpp
@@ -1,8 +1,13 @@
 #include "GitPack.h"
-#include "../zlib.h"
 #include <QDebug>
 #include <QFile>
 #include "GitPackIdxV2.h"
+
+#ifdef Q_WS_WIN
+  #include <QtZlib/zlib.h>
+#else
+  #include <zlib.h>
+#endif
 
 void GitPack::decodeTree(QByteArray *out)
 {

--- a/zlib.h
+++ b/zlib.h
@@ -1,1 +1,0 @@
-#include <QtZlib/zlib.h>


### PR DESCRIPTION
Linux でビルドできなかったため -lz をつかいビルドできるように変更