### PR TITLE
refactor(MainWindow): remove unused and unexported function

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3452,18 +3452,17 @@ bool MainWindow::runOnCurrentRepositoryDir(std::function<void(QString)> callback
 	return false;
 }
 
+#ifdef Q_OS_MAC
 namespace {
 
 bool isValidDir(QString const &dir)
 {
-	if (dir.indexOf('\"') >= 0) return false;
-#ifndef Q_OS_WIN
-	if (dir.indexOf('\\') >= 0) return false;
-#endif
+	if (dir.indexOf('\"') >= 0 || dir.indexOf('\\') >= 0) return false;
 	return QFileInfo(dir).isDir();
 }
 
 }
+#endif
 
 void MainWindow::openTerminal()
 {


### PR DESCRIPTION
isValidDirはMac環境でしか使われていないので`#ifdef`をいじって警告が出ないように