### PR TITLE
Move left panel widget to a dock widget

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -169,6 +169,8 @@ MainWindow::MainWindow(QWidget *parent)
 			setWindowState(state);
 		}
 	}
+	
+	createDockWindows();
 
 //	setTabOrder(ui->treeWidget_repos, ui->widget_log);
 
@@ -2285,6 +2287,14 @@ void MainWindow::setNetworkingCommandsEnabled(bool f)
 bool MainWindow::isOnlineMode() const
 {
 	return m->is_online_mode;
+}
+
+void MainWindow::createDockWindows()
+{
+	QDockWidget *repoDock = new QDockWidget(tr("Repositories"), this);
+	repoDock->setWidget(ui->stackedWidget_leftpanel);
+	addDockWidget(Qt::LeftDockWidgetArea, repoDock);
+	ui->menu_Window->addAction(repoDock->toggleViewAction());
 }
 
 void MainWindow::setRemoteOnline(bool f)

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -39,6 +39,8 @@ public:
 	bool isOnlineMode() const override;
 private:
 	Ui::MainWindow *ui;
+	
+	void createDockWindows();
 
 	void updateFilesList(QString id, bool wait) override;
 	void updateFilesList(Git::CommitItem const &commit, bool wait);


### PR DESCRIPTION
Following the dockable panels issue covered in https://github.com/soramimi/Guitar/issues/33, I've moved the repository list widgets to a dedicated dock window and integrated the new window in Guitar's "Window" menu.