### PR TITLE
Build and upload AppImage for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt59base qt59svg libgl1-mesa-dev libssl-dev zlib1g-dev ruby # openssl-1.1.x is not supported!
+  - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - ruby prepare.rb
+  - mkdir -p _bin/ && cp /usr/lib/x86_64-linux-gnu/libz.a _bin/ # FIXME: Why is this needed?
+  - qmake CONFIG+=release PREFIX=/usr
+  - make -j$(nproc)
+  # FIXME: make: Nothing to be done for `install'.
+  # make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
+  - mkdir -p appdir/usr/bin && cp _bin/Guitar appdir/usr/bin/guitar && strip appdir/usr/bin/guitar && chmod a+x appdir/usr/bin/guitar
+  - mkdir -p appdir/usr/share/icons/hicolor/scalable/apps && cp LinuxDesktop/Guitar.svg appdir/usr/share/icons/hicolor/scalable/apps/guitar.svg
+  - mkdir -p appdir/usr/share/applications && cp LinuxDesktop/guitar.desktop appdir/usr/share/applications/
+  - mkdir -p appdir/usr/share/metainfo && cp LinuxDesktop/guitar.appdata.xml appdir/usr/share/metainfo/
+  - find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Guitar*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/LinuxDesktop/guitar.appdata.xml
+++ b/LinuxDesktop/guitar.appdata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>guitar</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-2.0+</project_license>
+	<name>Guitar</name>
+	<summary>Git GUI Client</summary>
+	<description>
+		<p>Guitar is a graphical frontend for the git distributed version control system. It has logs, graphs, and a diff view.</p>
+	</description>
+	<launchable type="desktop-id">guitar.desktop</launchable>
+	<url type="homepage">https://github.com/soramimi/Guitar</url>
+	<screenshots>
+		<screenshot type="default">
+			<image>https://camo.githubusercontent.com/851ca9188bb22d726e8d06b9e7cfdd16d0f0c128/68747470733a2f2f736f72616d696d692e6769746875622e696f2f4775697461722f73637265656e73686f74732f7562756e74752e706e67</image>
+		</screenshot>
+	</screenshots>
+	<provides>
+		<id>guitar.desktop</id>
+	</provides>
+</component>

--- a/LinuxDesktop/guitar.desktop
+++ b/LinuxDesktop/guitar.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Guitar
+Comment=Graphical git client
+Categories=Development;
+Exec=guitar
+Icon=guitar


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines
- Decentralized

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.