### PR TITLE
Added ability to change the repo name property in the bookmark list

### DIFF
--- a/src/BasicMainWindow.cpp
+++ b/src/BasicMainWindow.cpp
@@ -1731,6 +1731,9 @@ void MainWindow::execRepositoryPropertyDialog(RepositoryItem const &repo, bool o
 	if (dlg.isRemoteChanged()) {
 		emit remoteInfoChanged();
 	}
+    if (dlg.isNameChanged()) {
+        this->changeRepositoryBookmarkName(repo, dlg.getName());
+    }
 }
 
 void MainWindow::execSetUserDialog(Git::User const &global_user, Git::User const &repo_user, QString const &reponame)
@@ -2605,6 +2608,12 @@ void MainWindow::saveRepositoryBookmark(RepositoryItem item)
 	}
 	saveRepositoryBookmarks();
 	updateRepositoriesList();
+}
+
+void MainWindow::changeRepositoryBookmarkName(RepositoryItem item, QString new_name)
+{
+    item.name = new_name;
+    saveRepositoryBookmark(item);
 }
 
 void MainWindow::setCurrentRepository(RepositoryItem const &repo, bool clear_authentication)

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -310,6 +310,7 @@ private:
 //	static int getHunkIndex(QListWidgetItem *item);
 	static void updateSubmodules(GitPtr g, const QString &id, QList<Git::SubmoduleItem> *out);
 	void saveRepositoryBookmark(RepositoryItem item);
+    void changeRepositoryBookmarkName(RepositoryItem item, QString new_name);
 	int rowFromCommitId(RepositoryWrapperFrame *frame, const QString &id);
 	QList<Git::Tag> findTag(RepositoryWrapperFrame *frame, const QString &id);
 	void sshSetPassphrase(const std::string &user, const std::string &pass);

--- a/src/RepositoryPropertyDialog.cpp
+++ b/src/RepositoryPropertyDialog.cpp
@@ -20,8 +20,11 @@ RepositoryPropertyDialog::RepositoryPropertyDialog(MainWindow *parent, Git::Cont
 
 	ui->groupBox_remote->setVisible(open_repository_menu);
 
-	ui->label_name->setText(repository.name);
-	ui->lineEdit_local_dir->setText(misc::normalizePathSeparator(repository.local_dir));
+    ui->label_editable_name->setText(repository.name);
+    ui->label_editable_name->setVisible(true);
+    ui->lineEdit_name->setText(repository.name);
+    ui->lineEdit_name->setVisible(false);
+    ui->lineEdit_local_dir->setText(misc::normalizePathSeparator(repository.local_dir));
 
 	updateRemotesTable();
 }
@@ -128,6 +131,16 @@ bool RepositoryPropertyDialog::isRemoteChanged() const
 	return remote_changed;
 }
 
+bool RepositoryPropertyDialog::isNameChanged() const
+{
+    return name_changed;
+}
+
+QString RepositoryPropertyDialog::getName()
+{
+    return repository.name;
+}
+
 void RepositoryPropertyDialog::on_pushButton_remote_add_clicked()
 {
 	Git::Remote r;
@@ -165,4 +178,26 @@ void RepositoryPropertyDialog::on_pushButton_remote_remove_clicked()
 void RepositoryPropertyDialog::on_pushButton_remote_menu_clicked()
 {
 	toggleRemoteMenuActivity();
+}
+
+void RepositoryPropertyDialog::on_pushButton_edit_name_clicked()
+{
+    if (ui->pushButton_edit_name->text() == "Edit Name")
+    {
+        ui->pushButton_edit_name->setText("Save");
+        ui->label_editable_name->setVisible(false);
+        ui->lineEdit_name->setVisible(true);
+    }
+    else
+    {
+        if (!ui->lineEdit_name->text().isEmpty())
+        {
+            name_changed = true;
+            repository.name = ui->lineEdit_name->text();
+            ui->label_editable_name->setText(ui->lineEdit_name->text());
+            ui->pushButton_edit_name->setText("Edit Name");
+            ui->label_editable_name->setVisible(true);
+            ui->lineEdit_name->setVisible(false);
+        }
+    }
 }

--- a/src/RepositoryPropertyDialog.h
+++ b/src/RepositoryPropertyDialog.h
@@ -19,6 +19,7 @@ private:
 	Ui::RepositoryPropertyDialog *ui;
 	RepositoryItem repository;
 	bool remote_changed = false;
+    bool name_changed = false;
 	Git::Context const *gcx;
 	void updateRemotesTable();
 	bool execEditRemoteDialog(Git::Remote *remote, EditRemoteDialog::Operation op);
@@ -29,11 +30,14 @@ public:
 	~RepositoryPropertyDialog() override;
 
 	bool isRemoteChanged() const;
+    bool isNameChanged() const;
+    QString getName();
 private slots:
 	void on_pushButton_remote_add_clicked();
 	void on_pushButton_remote_edit_clicked();
 	void on_pushButton_remote_remove_clicked();
 	void on_pushButton_remote_menu_clicked();
+    void on_pushButton_edit_name_clicked();
 };
 
 #endif // REPOSITORYPROPERTYDIALOG_H

--- a/src/RepositoryPropertyDialog.ui
+++ b/src/RepositoryPropertyDialog.ui
@@ -47,24 +47,68 @@
        <number>16</number>
       </property>
       <item>
-       <widget class="QLabel" name="label_name">
-        <property name="font">
-         <font>
-          <pointsize>15</pointsize>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">QLabel {
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="label_name">
+          <property name="font">
+           <font>
+            <pointsize>15</pointsize>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QLabel {
 	background: transparent;
 }
 </string>
-        </property>
-        <property name="text">
-         <string>TextLabel</string>
-        </property>
-       </widget>
+          </property>
+          <property name="text">
+           <string>Name: </string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_editable_name">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>15</pointsize>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>TextLabel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_name">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_edit_name">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Edit Name</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
I have several repos which have similar source folder names. Since the repo name is derived from the folder name, I end up with multiple repo names in the bookmark list so I cannot easily determine which one I need to open.

I love Guitar however this is a problem for me so to address this, I have added the ability to change the repo name property in the bookmark list when viewing the repo properties. 

Since the repo name is effectively an alias, the user can change it to be more descriptive.  I have not done anything with translation in Qt before so that may need to be considered. I would be happy to make changes if required.

I hope this is a useful contribution :-)