### PR TITLE
Fix long lines being word-breaked, then hidden, in TextEditorWidget

### DIFF
--- a/src/texteditor/TextEditorWidget.cpp
+++ b/src/texteditor/TextEditorWidget.cpp
@@ -635,16 +635,17 @@ void TextEditorWidget::paintEvent(QPaintEvent *)
         int view_row = 0;
         int line_row = editor_cx->scroll_row_pos;
         int lh = lineHeight();
+        int scroll = xScrollPosInPixel();
         pr.save();
         pr.setClipRect(linenum_width, 0, width() - linenum_width, height());
         while (isValidRowIndex(line_row)) {
-            int x = linenum_width - xScrollPosInPixel();
+            int x = linenum_width - scroll;
             int y = view_row * lh;
             if (y >= height()) break;
             QList<FormattedLine> fline = formatLine2(line_row);
             for (FormattedLine const &fl : fline) {
                 pr.setPen(defaultForegroundColor());
-                pr.drawText(QRect(x, y, width() - linenum_width, lh), fl.text);
+                pr.drawText(QRect(x, y, width() - linenum_width + scroll, lh), Qt::TextSingleLine, fl.text);
             }
             view_row++;
             line_row++;


### PR DESCRIPTION
The version of Guitar that I'm using (which is the one from my last PR, but the current continuous version has the same problem) omits the last word from lines that are longer than what the diff window can show:

![image](https://user-images.githubusercontent.com/243563/175290682-b9330cb9-0ba5-4a16-b9d5-d583b19598f6.png)

This PR fixes this:

![image](https://user-images.githubusercontent.com/243563/175290736-ebde0e98-8ae0-4c4f-a554-e287b84cc148.png)

It seems like the default flags of the QPainter try to word wrap the long line, then the clip rectangle kicks in and removes the second line.


I've seen you worked a lot on the text editor, so the problem may not exist in the current version, but as the latest continous version still has the bug, I decided to make a PR anyway. Feel free to ignore if it doesn't fit into your development.

