### PR TITLE
CMake: Add Qt 6 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(Guitar
 )
 set(CMAKE_CXX_EXTENSIONS  OFF)
 set(CMAKE_CXX_STANDARD    17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -19,15 +20,52 @@ set(CMAKE_DISABLE_SOURCE_CHANGES  ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
-find_package(Qt5 COMPONENTS Core Widgets Network Svg REQUIRED)
-find_package(zlib REQUIRED )
-find_package(OpenSSL REQUIRED )
-find_package(Qt5LinguistTools REQUIRED)
+option(BUILD_WITH_QT5 "Build with Qt 5" OFF)
+option(BUILD_WITH_QT6 "Build with Qt 6" OFF)
+
+if(BUILD_WITH_QT6)
+	set(QT_VERSION_MAJOR 6)
+elseif(BUILD_WITH_QT5)
+	set(QT_VERSION_MAJOR 5)
+endif()
+
+if(NOT QT_VERSION_MAJOR)
+	message(STATUS "QT_VERSION_MAJOR, BUILD_WITH_QT5 or BUILD_WITH_QT6 not set, detecting Qt version...")
+	find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+endif()
+
+if(QT_VERSION_MAJOR EQUAL 6)
+	set(QT_MIN_VERSION 6.0)
+elseif(QT_VERSION_MAJOR EQUAL 5)
+	set(QT_MIN_VERSION 5.0)
+else()
+	message(FATAL_ERROR "Invalid QT_VERSION_MAJOR.")
+endif()
+
+set(QT_DEFAULT_MAJOR_VERSION ${QT_VERSION_MAJOR})
+
+set(QT_COMPONENTS Core Gui Widgets Network Svg LinguistTools)
+if(QT_VERSION_MAJOR EQUAL 6)
+	list(APPEND QT_COMPONENTS Core5Compat)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} ${QT_MIN_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
+
+if(QT_VERSION_MAJOR EQUAL 5 AND Qt5Core_VERSION VERSION_LESS 5.15.0)
+	macro(qt_add_translation)
+		qt5_add_translation(${ARGN})
+	endmacro()
+endif()
+
+find_package(zlib REQUIRED)
+find_package(OpenSSL REQUIRED)
 if(WIN32)
 	# check package at
 	# https://github.com/rprichard/winpty
 	find_package(winpty REQUIRED )
 endif()
+
+find_library(MAGIC_LIBRARIES NAMES magic libmagic HINTS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 REQUIRED)
+find_path(MAGIC_INCLUDE_DIRS NAMES magic.h PATHS /usr/include /usr/local/include REQUIRED)
 
 # extract version information
 string(TIMESTAMP Guitar_copyright_year "%Y")

--- a/extra/FileView/CMakeLists.txt
+++ b/extra/FileView/CMakeLists.txt
@@ -28,9 +28,17 @@ list(REMOVE_ITEM FileView_SOURCES ${CMAKE_SOURCE_DIR}/src/main.cpp)
 # main.cpp以外のSourceをコンパイル
 add_library(fileview-lib ${FileView_SOURCES})
 target_link_libraries(fileview-lib PUBLIC
-	Qt5::Widgets
-	Qt5::Network
-	Qt5::Svg)
+	Qt${QT_VERSION_MAJOR}::Core
+	Qt${QT_VERSION_MAJOR}::Network
+	Qt${QT_VERSION_MAJOR}::Gui
+	Qt${QT_VERSION_MAJOR}::Widgets
+	Qt${QT_VERSION_MAJOR}::Svg
+)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+	target_link_libraries(fileview-lib PUBLIC Qt${QT_VERSION_MAJOR}::Core5Compat)
+endif()
+
 target_include_directories(fileview-lib PUBLIC ${CMAKE_BINARY_DIR})
 target_include_directories(fileview-lib PUBLIC ${PROJECT_SOURCE_DIR})
 target_include_directories(fileview-lib PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_definitions(-DAPP_GUITAR)
 
 # Sourceを再帰的に取得
-file(GLOB_RECURSE Guitar_SOURCES  ./*.cpp)
-
+file(GLOB_RECURSE Guitar_SOURCES  ./*.cpp ../filetype/*.cpp)
 
 if(WIN32)
 # win32環境においてunix関係のアイテムを使用しないように
@@ -22,7 +21,7 @@ file(GLOB_RECURSE Guitar_UIS  ./*.ui)
 file(GLOB_RECURSE Guitar_RESOURCES   ./resources/*.qrc)
 
 file(GLOB_RECURSE Guitar_TRANSLATIONS  ./resources/translations/*.ts)
-qt5_add_translation(Guitar_QM_FILES ${Guitar_TRANSLATIONS})
+qt_add_translation(Guitar_QM_FILES ${Guitar_TRANSLATIONS})
 
 configure_file(${Guitar_RESOURCES} ${CMAKE_BINARY_DIR} COPYONLY)
 
@@ -33,19 +32,26 @@ add_dependencies(resources translations)
 # Sourceをライブラリとして構築する
 add_library(guitar-lib ${Guitar_SOURCES})
 target_link_libraries(guitar-lib PUBLIC
-	Qt5::Widgets
-	Qt5::Network
-	Qt5::Svg
+	Qt${QT_VERSION_MAJOR}::Core
+	Qt${QT_VERSION_MAJOR}::Network
+	Qt${QT_VERSION_MAJOR}::Gui
+	Qt${QT_VERSION_MAJOR}::Widgets
+	Qt${QT_VERSION_MAJOR}::Svg
 	zlib 
 	OpenSSL::SSL
 	OpenSSL::Crypto
+	${MAGIC_LIBRARIES}
 	)
 
+if(QT_VERSION_MAJOR EQUAL 6)
+	target_link_libraries(guitar-lib PUBLIC Qt${QT_VERSION_MAJOR}::Core5Compat)
+endif()
 
 # ライブラリに読み込むHeaderの設定
 target_include_directories(guitar-lib PUBLIC ${CMAKE_BINARY_DIR})
 target_include_directories(guitar-lib PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(guitar-lib PUBLIC ${PROJECT_SOURCE_DIR}/src/texteditor)
+target_include_directories(guitar-lib PUBLIC ${PROJECT_SOURCE_DIR}/src/coloredit)
 
 set_target_properties(guitar-lib PROPERTIES OUTPUT_NAME guitar)
 


### PR DESCRIPTION
This adds Qt 6 support and fixes a few minor problems with the CMake files. DarkStylePlugin.{cpp,h} gets included and should probably be deleted as it does not build and does not seem to be used by the project.