### PR TITLE
Cleanup: fix warnings due to comparison between signed and unsigned integers

### DIFF
--- a/src/FileDiffWidget.cpp
+++ b/src/FileDiffWidget.cpp
@@ -385,8 +385,8 @@ void FileDiffWidget::setDiffText(Git::Diff const &diff, TextDiffLineList const &
 
 	m->linefragmentpair.clear();
 
-	int ileft = 0;
-	int iright = 0;
+	std::size_t ileft = 0;
+	std::size_t iright = 0;
 	while (ileft < left_dels.size() && iright < right_adds.size()) {
 		if (left_dels[ileft].line_index < right_adds[iright].line_index) {
 			ileft++;
@@ -828,7 +828,7 @@ void FileDiffWidget::refrectScrollBar(/*bool updateformat*/)
 
 			const size_t n = std::min(llines->size(), rlines->size());
 
-			for (int i = 0; i < n; i++) {
+			for (std::size_t i = 0; i < n; i++) {
 				std::vector<Char> *lchars = llines->chars(i);
 				std::vector<Char> *rchars = rlines->chars(i);
 				size_t l = 0;

--- a/src/Git.cpp
+++ b/src/Git.cpp
@@ -73,7 +73,7 @@ bool Git::CommitID::isValid() const
 {
 	if (!valid) return false;
 	uint8_t c = 0;
-	for (int i = 0; i < sizeof(id); i++) {
+	for (std::size_t i = 0; i < sizeof(id); i++) {
 		c |= id[i];
 	}
 	return c != 0; // すべて0ならfalse

--- a/src/texteditor/TextEditorView.cpp
+++ b/src/texteditor/TextEditorView.cpp
@@ -776,7 +776,7 @@ void TextEditorView::paintEvent(QPaintEvent *)
 		for (int pass = 0; pass < 3; pass++) {
 			int view_row = 0; // 描画行番号（ビューポートの左上隅を0とした行位置）
 			int line_row = editor_cx->scroll_row_pos; // 行インデックス（view_row位置に描画すべき論理行インデックス）
-			for (int i = 0; i < m->formatted_lines.size(); i++) {
+			for (std::size_t i = 0; i < m->formatted_lines.size(); i++) {
 				const bool iscurrentline = (line_row == editor_cx->current_row); // 現在の行？
 				const int text_origin_y = view_row * line_height; // テキスト原点座標Y（ピクセル単位）
 
@@ -865,7 +865,7 @@ void TextEditorView::paintEvent(QPaintEvent *)
 				auto DrawText = [&](){
 					int left_x = 0;
 					int right_x = 0;
-					int j = 0;
+					std::size_t j = 0;
 					while (j < chars.size()) {
 						int n = 0;
 						QString text;


### PR DESCRIPTION
While building Guitar on Linux (Ubuntu 22.04.3 LTS), a few warnings pop up such as the ones shown below: 

```
(...)
/home/rui/develop/qt/Guitar/src/FileDiffWidget.cpp:390: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<FileDiffWidget::LineFragment>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
../../../src/FileDiffWidget.cpp: In member function ‘void FileDiffWidget::setDiffText(const Git::Diff&, const TextDiffLineList&, const TextDiffLineList&)’:
../../../src/FileDiffWidget.cpp:390:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<FileDiffWidget::LineFragment>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  390 |         while (ileft < left_dels.size() && iright < right_adds.size()) {
      |                ~~~~~~^~~~~~~~~~~~~~~~~~
(...)
```

This PR fixes these warnings by declaring index types as `std::size_t` instead of `int`.