### PR TITLE
Fix bug #117 by enclosing filename in double quotes

### DIFF
--- a/src/Git.cpp
+++ b/src/Git.cpp
@@ -1114,7 +1114,7 @@ bool Git::cat_file(CommitID const &id, QByteArray *out)
 
 void Git::resetFile(QString const &path)
 {
-	git("checkout -- " + path);
+	git("checkout -- \"" + path + "\"");
 }
 
 void Git::resetAllFiles()


### PR DESCRIPTION
This PR fixes #117 by enclosing the filename in double quotes to handle filenames with spaces.